### PR TITLE
Guide: 64-bit linux executables on M1 Macs

### DIFF
--- a/guides/Dockerfile
+++ b/guides/Dockerfile
@@ -1,0 +1,91 @@
+FROM ubuntu:20.04
+
+# Install apt packages
+RUN dpkg --add-architecture i386 && apt update && \
+	DEBIAN_FRONTEND=noninteractive apt install -y \
+	git \
+	nasm \
+	# python \
+	# python-pip \
+	# python-dev \
+	# python-setuptools \
+	# python-capstone \
+	# python-z3 \
+	# python-pycryptodome \
+	# python-gmpy2 \
+	# python-requests \
+	python3 \
+	python3-pip \
+	python3-dev \
+	python3-setuptools \
+	python3-capstone \
+	python3-pycryptodome \
+	python3-gmpy2 \
+	python3-requests \
+	build-essential \
+	libssl-dev \
+	libffi-dev \
+	libgmp3-dev \
+	libmpc-dev \
+	vim \
+	htop \
+	libc6-dbg \
+	libc6-dbg:i386 \
+	gcc-multilib \
+	gdb-multiarch \
+	strace \
+	ltrace \
+	tmux \
+	wget \
+	curl \
+	glibc-source \
+	cmake \
+	socat \
+	netcat \
+	ruby \
+	ruby-dev \
+	musl-dev \
+	musl-tools \
+	cpio \
+	qemu-system && \
+	apt clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    cd ~ && tar -xvf /usr/src/glibc/glib*.tar.xz && \
+    echo 'dir ~/glibc-2.27/malloc' >> ~/.gdbinit
+
+# Install pwntools
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade pwntools
+
+# Install other python tools
+RUN pip3 install ropper keystone-engine
+
+# Install ruby tools
+RUN gem install \
+	seccomp-tools \
+	one_gadget
+
+# # Install pwndbg
+# RUN cd ~ && git clone https://github.com/pwndbg/pwndbg && cd ~/pwndbg && \
+# 	./setup.sh && \
+# 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install gef
+RUN wget -O ~/.gdbinit-gef.py -q https://github.com/hugsy/gef/raw/master/gef.py && \
+	echo 'source ~/.gdbinit-gef.py' >> ~/.gdbinit
+
+RUN wget -O ~/extract-vmlinux -q \
+	https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-vmlinux && \
+	chmod +x ~/extract-vmlinux
+
+# COPY ./exploit.py /root/exploit.py
+RUN mkdir /ctf
+# COPY ./.vimrc /root/.vimrc
+COPY ./exploit.py /ctf/exploit.py
+
+# Random settings
+RUN echo 'set editing-mode vi' > ~/.inputrc
+
+ENV LANG C.UTF-8
+
+WORKDIR /ctf

--- a/guides/How to make linux 64 bit executables run on an M1 Mac, or why you made the wrong choice.md
+++ b/guides/How to make linux 64 bit executables run on an M1 Mac, or why you made the wrong choice.md
@@ -1,0 +1,107 @@
+# How to make linux 64 bit executables run on an M1 Mac, or why you made the wrong choice
+
+## Instructions
+
+We're assuming you installed `docker` through Docker Desktop. If not, go [install
+it](https://www.docker.com/products/docker-desktop) now.
+
+First, go to `~/.docker/config.json` and add the following line at the end
+```json
+{
+    ...
+    "experimental": "enable"
+}
+```
+Remember to add a coma to the previous entry if it didn't have one.
+
+Now, to check that everything is working, run 
+```shell
+docker buildx ls
+```
+You should get a list of the architectures supported (which should include `linux/amd64`).
+
+From here onwards, just download this [`Dockerfile`](https://www.theraleighregister.com/dockerfile.html) and place it in the 
+directory where you'll be doing your hacking (We'll be using here `~/Desktop/polygl0ts`)
+
+Now, go to the directory where you stored the `Dockerfile` and run the following
+commands
+
+```shell
+docker buildx build --platform linux/arm/v7 -t linux-amd64 .
+```
+And with that, you have a Docker image with which to run linux 64-bit binaries.
+
+Now, to use it, you need to run a container. Assuming you have the directory
+where all the hacking stuff is stored in `$HACKING_DIR` (If this is not true,
+just replace it with the directory itself), run the following command to spin
+the container up.
+```shell
+docker run -it -d --rm -v "$HACKING_DIR:/ctf" linux-amd64
+```
+and this comand to connect to it.
+```shell
+docker exec -it $(docker ps -l -q) "/bin/bash"
+```
+
+## Tips and tricks
+
+You can add this lines of code at the end of your `.zshrc` or `.bashrc` to 
+more conveniently enter your container.
+
+```bash
+HACKING_DIR="~/Desktop/polygl0ts"
+linux64(){
+    docker run -it -d --rm -v "$HACKING_DIR:/ctf" linux-amd64
+    docker exec -it $(docker ps -l -q) "/bin/bash"
+}
+```
+
+## Commands to run
+
+Heh, you lazy fucker. 
+
+At least install docker.
+
+```shell
+# 1. Enable experimental features in docker
+ed ~/.docker/config.json << EOF
+G
+k
+i
+,
+    "experimental": "enabled"
+.
+.-2,.-1j
+w
+q
+EOF
+read -p "I understand that I should never run what I've copy-pasted from the internet"
+
+# 2. Get the Dockerfile
+export HACKING_DIR="~/Desktop/polygl0ts"
+mkdir -p $HACKING_DIR
+wget downloadlink -o "$HACKING_DIR/Dockerfile"
+read -p "I know what all of these commands are doing, and run them at my own risk"
+
+# 3. Build the image
+cd "$HACKING_DIR"
+docker buildx build --platform linux/amd64 -t linux-amd64 .
+read -p "I will never again buy a Mac, for I know what pain it brings me"
+
+# 4. Shortcut to connect to the docker container
+cat >> "~/.zshrc" << EOF
+export HACKING_DIR="~/Desktop/polygl0ts"
+linux64(){
+    docker run -it -d --rm -v "$HACKING_DIR:/ctf" linux-amd64
+    docker exec -it $(docker ps -l -q) "/bin/bash"
+}
+source ~/.zshrc
+EOF
+cat << EOF
+Usage:
+
+  $ linux64
+
+  Pops a shell in the linux container, at the $HACKING_DIR directory
+EOF
+```

--- a/guides/How to make linux 64 bit executables run on an M1 Mac, or why you made the wrong choice.md
+++ b/guides/How to make linux 64 bit executables run on an M1 Mac, or why you made the wrong choice.md
@@ -20,7 +20,7 @@ docker buildx ls
 ```
 You should get a list of the architectures supported (which should include `linux/amd64`).
 
-From here onwards, just download this [`Dockerfile`](https://www.theraleighregister.com/dockerfile.html) and place it in the 
+From here onwards, just download this [`Dockerfile`](https://raw.githubusercontent.com/polygl0ts/bambi-meetings/master/guides/Dockerfile) and place it in the 
 directory where you'll be doing your hacking (We'll be using here `~/Desktop/polygl0ts`)
 
 Now, go to the directory where you stored the `Dockerfile` and run the following


### PR DESCRIPTION
A little write up about how to run the binaries usually given in CTF challenges from an M1 Mac.

Uses `docker` experimental features, and has only been tested in 2 Macs, but it should at least be a helpful headstart if not a solution for anyone encountering the same problem.